### PR TITLE
Base path typo fix introduced in #2

### DIFF
--- a/src/MorphMapGeneratorServiceProvider.php
+++ b/src/MorphMapGeneratorServiceProvider.php
@@ -27,7 +27,7 @@ class MorphMapGeneratorServiceProvider extends ServiceProvider
 
         if (config('morph-map-generator.autogenerate')) {
             $discoveredModels = DiscoverModels::create()
-                ->withBasePath(base_path(config('morph-map.generator.base_directory')))
+                ->withBasePath(base_path(config('morph-map-generator.base_directory')))
                 ->withPaths(config('morph-map-generator.paths'))
                 ->withBaseModels(config('morph-map-generator.base_models'))
                 ->ignoreModels(config('morph-map-generator.ignored_models'))


### PR DESCRIPTION
It seems like I somehow managed to sneak in a typo in the `MorphMapGeneratorServiceProvider`. This PR aims to fix that issue.

My sincere apologies for this blunder.