### PR TITLE
Read from cache or re-discover in boot method

### DIFF
--- a/src/MorphMapGeneratorServiceProvider.php
+++ b/src/MorphMapGeneratorServiceProvider.php
@@ -16,8 +16,20 @@ class MorphMapGeneratorServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/morph-map-generator.php', 'morph-map-generator');
 
         $this->bindCacheDriver();
+    }
 
-        $cache = $this->app->make(MorphMapCacheDriver::class);
+    public function boot(MorphMapCacheDriver $cache): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/morph-map-generator.php' => config_path('morph-map-generator.php'),
+            ], 'config');
+
+            $this->commands([
+                CacheMorphMapCommand::class,
+                ClearMorphMapCommand::class,
+            ]);
+        }
 
         if ($cache->exists()) {
             Relation::morphMap($cache->get());
@@ -39,20 +51,6 @@ class MorphMapGeneratorServiceProvider extends ServiceProvider
             Relation::morphMap($morphMap);
 
             return;
-        }
-    }
-
-    public function boot(): void
-    {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__ . '/../config/morph-map-generator.php' => config_path('morph-map-generator.php'),
-            ], 'config');
-
-            $this->commands([
-                CacheMorphMapCommand::class,
-                ClearMorphMapCommand::class,
-            ]);
         }
     }
 


### PR DESCRIPTION
Using the `LaravelMorphMapCacheDriver` results in a "Target class [cache.store] does not exist." exception being thrown, as the cache repository cannot be resolved during service provider registration. By moving the code in question into the boot method, the morph map is generated after the fact, when the repository is available and resolvable.