### PR TITLE
Add support for custom morph class resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ abstract class BaseModel extends Model
 }
 ```
 
-When a model is not implementing `getMorphClass`, it will throw an exception when building the generated morph map, making it possible to quickly find models that do not have a morph map entry. 
+When a model is not implementing `getMorphClass`, it will throw an exception when building the generated morph map, making it possible to quickly find models that do not have a morph map entry.
 
 When `autogenerate` is enabled in the `morph-map-generator` config file, the morph map in your application will be dynamically generated each time the application boots. This is great in development environments since each time your application boots, the morph map is regenerated. For performanc reasons, you should cache the dynamically generated morph map by running the following command:
 
@@ -136,6 +136,19 @@ Removing a cached morph map can be done by running:
 ```php
 php artisan morph-map:clear
 ```
+
+### Using a custom resolver
+
+You can also determine morph class values programmatically by using a custom resolver. For example, you could use the following to automatically derive the value based on the singular form of the model's table name:
+
+```php
+use Illuminate\Support\Str;
+use Spatie\LaravelMorphMapGenerator\MorphMapGenerator;
+
+MorphMapGenerator::resolveUsing(fn ($model) => Str::singular($model->getTable()));
+```
+
+You may set the resolver in the `boot` method of your `AppServiceProvider` or a separate service provider if needed.
 
 ### Models outside your path
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+         backupStaticAttributes="true"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="true"
+         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/src/MorphMapGenerator.php
+++ b/src/MorphMapGenerator.php
@@ -10,7 +10,7 @@ use Spatie\LaravelMorphMapGenerator\Exceptions\MorphClassCouldNotBeResolved;
 
 class MorphMapGenerator
 {
-    protected static $resolveCallback;
+    public static $resolveCallback;
 
     public static function create(): self
     {

--- a/src/MorphMapGenerator.php
+++ b/src/MorphMapGenerator.php
@@ -10,7 +10,7 @@ use Spatie\LaravelMorphMapGenerator\Exceptions\MorphClassCouldNotBeResolved;
 
 class MorphMapGenerator
 {
-    private static $resolveCallback;
+    protected static $resolveCallback;
 
     public static function create(): self
     {

--- a/src/MorphMapGenerator.php
+++ b/src/MorphMapGenerator.php
@@ -46,9 +46,11 @@ class MorphMapGenerator
         $model = $reflection->newInstanceWithoutConstructor();
 
         try {
-            $morph = static::$resolveCallback
-                ? call_user_func(static::$resolveCallback, $model)
-                : $model->getMorphClass();
+            if (static::$resolveCallback) {
+                $morph = call_user_func(static::$resolveCallback, $model);
+            }
+
+            $morph ??= $model->getMorphClass();
         } catch (Exception $exception) {
             throw MorphClassCouldNotBeResolved::exceptionThrown($reflection->getName(), $exception);
         }

--- a/tests/DiscoverModelsTest.php
+++ b/tests/DiscoverModelsTest.php
@@ -16,6 +16,8 @@ use Spatie\LaravelMorphMapGenerator\Tests\Fakes\GeneralModel;
 use Spatie\LaravelMorphMapGenerator\Tests\Fakes\OtherTypeModel;
 
 beforeEach(function () {
+    MorphMapGenerator::$resolveCallback = null;
+
     $this->discoverer = DiscoverModels::create()
         ->withBasePath(realpath(__DIR__ . '/../'))
         ->withRootNamespace('Spatie\LaravelMorphMapGenerator\\');

--- a/tests/DiscoverModelsTest.php
+++ b/tests/DiscoverModelsTest.php
@@ -78,6 +78,24 @@ it('can use multiple paths and base models', function () {
     ]);
 });
 
+it('can use a custom resolver', function () {
+    $this->discoverer
+        ->withBaseModels([BaseModel::class])
+        ->withPaths([__DIR__ . '/Fakes']);
+
+    // Use the table name as the morph class
+    MorphMapGenerator::resolveUsing(fn ($model) => $model->getTable());
+
+    $generated = $this->generator->generate(
+        $this->discoverer->discover()
+    );
+
+    expect($generated)->toEqual([
+        'event_models' => EventModel::class,
+        'general_models' => GeneralModel::class,
+    ]);
+});
+
 it('will handle exceptions', function () {
     $this->discoverer
         ->withBaseModels([BaseModel::class])

--- a/tests/DiscoverModelsTest.php
+++ b/tests/DiscoverModelsTest.php
@@ -94,6 +94,18 @@ it('can use a custom resolver', function () {
         'event_models' => EventModel::class,
         'general_models' => GeneralModel::class,
     ]);
+
+    // If the custom resolver returns null, it should fall back to getMorphClass
+    MorphMapGenerator::resolveUsing(fn ($model) => null);
+
+    $generated = $this->generator->generate(
+        $this->discoverer->discover()
+    );
+
+    expect($generated)->toEqual([
+        'event' => EventModel::class,
+        'general' => GeneralModel::class,
+    ]);
 });
 
 it('will handle exceptions', function () {


### PR DESCRIPTION
Hey there! This PR adds an optional `resolveUsing` setting to the morph map generator.

This is a similar idea to what was proposed in #3, but enables users to customize how the "default" alias is resolved by providing a callback.

For instance, you could base the morph names off the table name for each model like this:
```php
MorphMapGenerator::resolveUsing(fn ($model) => Str::singular($model->getTable()));
```

This would generate names like `post` or `comment` depending on the model's table name in the DB (which should be pretty stable even if you rearrange your model classes). This is just an example though, and you could add whatever logic you might want there.

Let me know what you think. Thanks!