### PR TITLE
fix: allow Laravel to handle class loading errors

### DIFF
--- a/src/DiscoverModels.php
+++ b/src/DiscoverModels.php
@@ -106,8 +106,12 @@ class DiscoverModels
         }
 
         foreach ($this->baseModels as $baseModelClass) {
-            if (is_subclass_of($class, $baseModelClass)) {
-                return true;
+            try {
+                if (is_subclass_of($class, $baseModelClass)) {
+                    return true;
+                }
+            } catch (\Throwable $e) {
+                // Allow Laravel to handle class loading errors, such as syntax errors.
             }
         }
 


### PR DESCRIPTION
I've noticed that the model check prevents Laravel from displaying errors in the handler; this change skips loading errors so that Laravel can handle them natively.

if there is a syntax error in a model that is not in use, the entire application stops

**BEFORE:**
<img width="455" height="307" alt="image" src="https://github.com/user-attachments/assets/2ca38265-f361-4738-a1fe-c21bad739f33" />


**AFTER:**
<img width="555" height="338" alt="image" src="https://github.com/user-attachments/assets/8050b015-121a-4f00-a7e2-d39e06f125a7" />
